### PR TITLE
Update Pillow requirement

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Guidelines for Codex
 
-- Install dependencies from `requirements.txt` before running tests.
+- Install dependencies from the updated `requirements.txt` before running tests.
 - Run tests with:
   ```bash
   SDL_VIDEODRIVER=dummy CAM_VIDEODRIVER=dummy pytest -q

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -7,4 +7,4 @@ pygame-menu
 pygame-vkeyboard
 psutil
 gpiozero
-Pillow==9.2.0
+Pillow>=10.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pluggy>=0.13.1
-Pillow==9.2.0
+Pillow>=10.2.0
 pygame>=1.9.6
 pygame-menu==4.0.7
 pygame-vkeyboard>=2.0.8

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ def main():
         python_requires=">=3.6",
         install_requires=[
             'picamera>=1.13 ; platform_machine>="armv0l" and platform_machine<="armv9l"',
-            'Pillow==9.2.0',
+            'Pillow>=10.2.0',
             'pygame>=1.9.6',
             'pygame-menu==4.0.7',
             'pygame-vkeyboard>=2.0.8',


### PR DESCRIPTION
## Summary
- update dependencies to support Python 3.12
- document using the updated requirements file for tests

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=. SDL_VIDEODRIVER=dummy CAM_VIDEODRIVER=dummy pytest -q` *(fails: AttributeError in factory tests)*

------
https://chatgpt.com/codex/tasks/task_e_6859c33e0a2c8324923b9dfcec5c7988