### PR TITLE
Fix PIL getsize call for Pillow 10

### DIFF
--- a/pibooth/fonts/__init__.py
+++ b/pibooth/fonts/__init__.py
@@ -72,7 +72,11 @@ def get_pil_font(text, font_name, max_width, max_height):
     while start < end:
         k = (start + end) // 2
         font = ImageFont.truetype(font_name, k)
-        font_size = font.getsize(text)
+        if hasattr(font, "getbbox"):
+            bbox = font.getbbox(text)
+            font_size = (bbox[2] - bbox[0], bbox[3] - bbox[1])
+        else:
+            font_size = font.getsize(text)
         if font_size[0] > max_width or font_size[1] > max_height:
             end = k
         else:

--- a/pibooth/pictures/factory.py
+++ b/pibooth/pictures/factory.py
@@ -235,7 +235,11 @@ class PictureFactory(object):
                 continue
             # Use PIL to draw text because better support for fonts than OpenCV
             font = fonts.get_pil_font(text, font_name, max_width, max_height)
-            _, text_height = font.getsize(text)
+            if hasattr(font, "getbbox"):
+                bbox = font.getbbox(text)
+                text_height = bbox[3] - bbox[1]
+            else:
+                _, text_height = font.getsize(text)
             (text_width, _baseline), (offset_x, offset_y) = font.font.getsize(text)
             if align == self.CENTER:
                 text_x += (max_width - text_width) // 2


### PR DESCRIPTION
## Summary
- compute text size with `getbbox` when Pillow>=10
- fallback to `getsize` if `getbbox` is unavailable

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `SDL_VIDEODRIVER=dummy CAM_VIDEODRIVER=dummy pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859c547ef448324bf1feeb7b08bbf9b