### PR TITLE
Fix gp_log_callback for Python3

### DIFF
--- a/pibooth/camera/gphoto.py
+++ b/pibooth/camera/gphoto.py
@@ -60,7 +60,11 @@ def get_gp_camera_proxy(port=None):
 def gp_log_callback(level, domain, string, data=None):
     """Logging callback for gphoto2.
     """
-    LOGGER.getChild('gphoto2').debug(domain.decode("utf-8") + u': ' + string.decode("utf-8"))
+    if isinstance(domain, bytes):
+        domain = domain.decode("utf-8")
+    if isinstance(string, bytes):
+        string = string.decode("utf-8")
+    LOGGER.getChild('gphoto2').debug(u"{}: {}".format(domain, string))
 
 
 class GpCamera(BaseCamera):

--- a/tests/test_gphoto.py
+++ b/tests/test_gphoto.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+
+import logging
+from pibooth.camera.gphoto import gp_log_callback
+
+
+def test_gp_log_callback_str(caplog):
+    with caplog.at_level(logging.DEBUG, logger="pibooth.gphoto2"):
+        gp_log_callback(None, 'Domain', 'Message')
+    assert "Domain: Message" in [r.getMessage() for r in caplog.records]
+
+
+def test_gp_log_callback_bytes(caplog):
+    with caplog.at_level(logging.DEBUG, logger="pibooth.gphoto2"):
+        gp_log_callback(None, b'Domain', b'Message')
+    assert "Domain: Message" in [r.getMessage() for r in caplog.records]


### PR DESCRIPTION
## Summary
- decode gphoto2 log strings only when bytes
- add regression tests for the log callback

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `SDL_VIDEODRIVER=dummy CAM_VIDEODRIVER=dummy pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859e03819e88324b0eb624b596e9439