### PR TITLE
Support EDITOR env var in open_text_editor

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,27 @@
+import os
+import subprocess
+from pibooth.utils import open_text_editor
+
+
+def test_open_text_editor_uses_env(monkeypatch):
+    calls = []
+
+    class DummyProc:
+        def __init__(self, cmd):
+            self.cmd = cmd
+            calls.append(cmd)
+            self.returncode = 0
+
+        def communicate(self):
+            return (b"", b"")
+
+    def fake_popen(cmd):
+        return DummyProc(cmd)
+
+    monkeypatch.setattr(subprocess, "Popen", fake_popen)
+    monkeypatch.setenv("EDITOR", "myeditor")
+
+    assert open_text_editor("file.txt")
+    assert calls[0][0] == "myeditor"
+    assert len(calls) == 1
+


### PR DESCRIPTION
## Summary
- prioritize `$EDITOR` in the text editor launch list
- parse editor command with shlex
- add regression test ensuring `$EDITOR` is used first

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `SDL_VIDEODRIVER=dummy CAM_VIDEODRIVER=dummy pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859f4171b8c8324aa6ef3d9a7ec2c46