### PR TITLE
Fix Swedish strings

### DIFF
--- a/pibooth/language.py
+++ b/pibooth/language.py
@@ -193,7 +193,7 @@ DEFAULT = {
     },
     'se': {
         'intro': "Ta en bild",
-        'intro_print': 'Eller så kan du\fortfarande\skriva ut den här bilden',
+        'intro_print': 'Eller så kan du\nfortfarande\nskriva ut den här bilden',
         'choose': "Välj layout",
         '1': "1 bild",
         '2': "2 bilder",
@@ -203,7 +203,7 @@ DEFAULT = {
         'smile': "Smile!",
         'processing': "Jobbar...",
         'print': "Skriv ut bilden!",
-        'print_forget': "Glöm\den här\bilden",
+        'print_forget': "Glöm\nden här\nbilden",
         'finished': "Tack",
         'oops': "Oops, nånting blev fel",
     },    


### PR DESCRIPTION
## Summary
- escape line breaks in Swedish translation

## Testing
- `PYTHONPATH=. SDL_VIDEODRIVER=dummy CAM_VIDEODRIVER=dummy pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859f6351de88324bf850982461f07a3