### PR TITLE
Update OS and Python version in install docs

### DIFF
--- a/docs/sources/install.rst
+++ b/docs/sources/install.rst
@@ -27,8 +27,8 @@ Hardware
 Software
 ^^^^^^^^
 
-* Raspberry Pi OS **Buster** (32 bit) with desktop (`could be downloaded here <https://downloads.raspberrypi.org/raspios_oldstable_armhf/images/>`_)
-* Python ``3.7.3``
+* Raspberry Pi OS **Bullseye** or **Bookworm** (32 bit) with desktop (`download images here <https://downloads.raspberrypi.org/raspios_armhf/images/>`_)
+* Python ``3.9`` or higher
 * libsdl2 ``2.0``
 * libgphoto2 ``2.5.27``
 * libcups ``2.2.10``


### PR DESCRIPTION
## Summary
- update instructions to reference Raspberry Pi OS Bullseye/Bookworm
- note support for Python 3.9+

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `SDL_VIDEODRIVER=dummy CAM_VIDEODRIVER=dummy pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a0019b21c8324b6d344bdf016eaca