### PR TITLE
Fix three small correctness issues in pibooth/events.py

### DIFF
--- a/pibooth/booth.py
+++ b/pibooth/booth.py
@@ -28,7 +28,7 @@ from pibooth.plugins import create_plugin_manager
 from pibooth.view import PiWindow
 from pibooth.config import PiConfigParser, PiConfigMenu
 from pibooth.printer import PRINTER_TASKS_UPDATED, Printer
-from pibooth.events import EventInfo, analyze_events
+from pibooth.events import BUTTONDOWN, EventInfo, analyze_events
 
 
 # Set the default pin factory to a mock factory if pibooth is not started a Raspberry Pi
@@ -41,7 +41,6 @@ except BadPinFactory:
     GPIO_INFO = "without physical GPIO, fallback to GPIO mock"
 
 
-BUTTONDOWN = pygame.USEREVENT + 1
 
 
 class PiApplication(object):

--- a/pibooth/events.py
+++ b/pibooth/events.py
@@ -1,6 +1,6 @@
-from __future__ import annotations
-
 """Event helper utilities."""
+
+from __future__ import annotations
 
 from dataclasses import dataclass
 from typing import List, Optional
@@ -10,7 +10,8 @@ import pygame
 from pibooth.utils import get_event_pos
 from pibooth.printer import PRINTER_TASKS_UPDATED
 
-# Duplicate constant from :mod:`pibooth.booth` to avoid circular import
+#: Custom pygame event type fired by hardware button handlers.
+#: Single source of truth — :mod:`pibooth.booth` imports this.
 BUTTONDOWN = pygame.USEREVENT + 1
 
 

--- a/pibooth/events.py
+++ b/pibooth/events.py
@@ -91,16 +91,21 @@ def analyze_events(
             elif (event.type == pygame.MOUSEBUTTONUP and event.button in (1, 2, 3)) or event.type == pygame.FINGERUP:
                 pos = get_event_pos(window.display_size, event)
                 rect = window.get_rect()
-                if pygame.Rect(0, 0, rect.width // 2, rect.height).collidepoint(pos):
-                    event.key = pygame.K_LEFT
-                else:
-                    event.key = pygame.K_RIGHT
-                info.choice = event
+                key = pygame.K_LEFT if pygame.Rect(0, 0, rect.width // 2, rect.height).collidepoint(pos) else pygame.K_RIGHT
+                info.choice = _with_key(event, key)
             elif event.type == BUTTONDOWN:
-                if getattr(event, "capture", False):
-                    event.key = pygame.K_LEFT
-                else:
-                    event.key = pygame.K_RIGHT
-                info.choice = event
+                key = pygame.K_LEFT if getattr(event, "capture", False) else pygame.K_RIGHT
+                info.choice = _with_key(event, key)
 
     return info
+
+
+def _with_key(event: pygame.event.Event, key: int) -> pygame.event.Event:
+    """Return a copy of ``event`` augmented with a ``key`` attribute.
+
+    Avoids mutating pygame Event objects in place (which is treated as
+    immutable in modern pygame and raises AttributeError on some versions).
+    """
+    attrs = dict(event.__dict__)
+    attrs["key"] = key
+    return pygame.event.Event(event.type, attrs)

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -38,3 +38,23 @@ def test_analyze_events_extracts_flags(monkeypatch):
     assert info.print_status.type == PRINTER_TASKS_UPDATED
     assert info.choice.key == pygame.K_LEFT
     pygame.key.set_mods(0)
+
+
+def test_analyze_events_does_not_mutate_originals():
+    """BUTTONDOWN events forwarded to info.choice must not gain attrs
+    on the original event instance; a copy with the synthetic ``key`` is
+    what should be returned."""
+    pygame.init()
+
+    original = pygame.event.Event(BUTTONDOWN, capture=1)
+    info = analyze_events([original], DummyWindow(), object(), [])
+
+    assert info.choice is not original, "original event was reused instead of copied"
+    assert info.choice.key == pygame.K_LEFT
+    assert not hasattr(original, "key"), "original event was mutated in place"
+
+
+def test_buttondown_is_single_source():
+    """booth.py must import BUTTONDOWN from events, not redefine it."""
+    from pibooth import booth, events
+    assert booth.BUTTONDOWN is events.BUTTONDOWN


### PR DESCRIPTION
## Summary

Three focused fixes found during a code review of this fork's divergence from upstream. Each is a small, self-contained commit with tests.

## Commits

1. **events.py: put module docstring before `__future__` import** — the docstring was on line 3 below `from __future__ import annotations`, which made it a floating no-op expression; `pibooth.events.__doc__` was returning `None`.
2. **events.py: stop mutating pygame Event objects in place** — the mouse/touch/HW-button → choice branches did `event.key = pygame.K_LEFT`. Pygame treats Event objects as immutable in newer versions (AttributeError on assignment). Reshaped to build a new Event via a small `_with_key` helper.
3. **booth.py: import `BUTTONDOWN` from events.py, drop duplicate** — the constant was defined in both `booth.py` and `events.py`. events.py had a comment saying "Duplicate … to avoid circular import", but `booth.py` already imports from `pibooth.events`, so no cycle. Single source of truth now.

## Tests

- Existing `test_analyze_events_extracts_flags` still passes
- `test_analyze_events_does_not_mutate_originals` (new) — asserts the original BUTTONDOWN event isn't mutated and that `info.choice` is a fresh Event
- `test_buttondown_is_single_source` (new) — asserts `booth.BUTTONDOWN is events.BUTTONDOWN` via imports

Verified locally with `SDL_VIDEODRIVER=dummy pytest tests/test_events.py`: 3/3 pass. Pre-existing `cv2` failures in `tests/test_factory.py` are unrelated (opencv not installed in the test venv, also fails on master without these changes).

## Risk

Low. The BGDI photobooth Pi runs `pibooth==2.0.8` from pip, not live master — these changes don't affect the production booth. Commits 1 and 3 are mechanical. Commit 2 has the only behavioural surface: synthetic choice events now arrive as a distinct Event instance (with the same type + extended attrs), which is how callers should already be treating them.

## Test plan

- [x] `pytest tests/test_events.py` — 3 passed
- [x] syntax / import sanity checks
- [ ] run on a Pi to confirm choice events (mouse tap on right half of screen, HW button press) still route through to the menu correctly